### PR TITLE
Limpieza y mejoras en scripts

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -1,17 +1,56 @@
 #!/system/bin/sh
 
-LOG_DIR=/data/adb/modules/Bootloop_Detector_Guardian/logs
+# --- LECTURA DINÁMICA DE PROPIEDADES ---
+# Leer propiedades directamente de module.prop para asegurar consistencia.
+# MODPATH es una variable global en el entorno de instalación de Magisk que apunta a la ruta de instalación.
+MODULE_PROP="$MODPATH/module.prop"
+
+# Extraer el ID, Nombre y Autor del módulo. grep y cut son herramientas estándar.
+MOD_ID=$(grep_prop id "$MODULE_PROP")
+MOD_NAME=$(grep_prop name "$MODULE_PROP")
+MOD_AUTHOR=$(grep_prop author "$MODULE_PROP")
+
+# Si no se puede obtener el nombre, usar el ID como fallback.
+[ -z "$MOD_NAME" ] && MOD_NAME=$MOD_ID
+
+# --- CONFIGURACIÓN DE RUTAS Y ARCHIVOS ---
+LOG_DIR="/data/adb/modules/$MOD_ID/logs"
+
+# Asegurar que el directorio de logs exista, saliendo si falla.
 mkdir -p "$LOG_DIR" || exit 1
 
+# Definir rutas completas a los archivos de log.
 LAST_MODULE_LOG="$LOG_DIR/last_active_module.log"
-
 BOOT_PROGRESS_LOG="$LOG_DIR/boot_progress.log"
 
+# --- INICIALIZACIÓN DE LOGS ---
+# Crear logs iniciales con información consistente.
+echo "$(date) - Módulo '$MOD_NAME' instalado/actualizado." > "$BOOT_PROGRESS_LOG"
+echo "Estado inicial: Módulo '$MOD_NAME' instalado correctamente." > "$LAST_MODULE_LOG"
 
-echo "$(date) - Módulo 'Bootloop Detector Guardian' instalado/actualizado." > "$BOOT_PROGRESS_LOG"
-echo "Modulo 'BootLoop Guardian' instalado." > "$LAST_MODULE_LOG"
 
-ui_print "- Module 'BootLoopGuardian🛡️' instaled correctly"
-ui_print "- This module will register the active modules before a This module will register the active modules before a bootloop."
-ui_print "- To search the problematic module go tho this dir:"
-ui_print "- /data/adb/modules/Bootloop_Detector_Guardian/logs/last_active_module.log"
+# --- MENSAJES AL USUARIO (ui_print) ---
+# Usar las variables para mostrar información precisa y consistente.
+
+ui_print " "
+ui_print "**********************************************"
+ui_print " Módulo: $MOD_NAME"
+ui_print " Autor: $MOD_AUTHOR"
+ui_print "**********************************************"
+ui_print " "
+ui_print "- ¡Instalación completada! $MOD_NAME está activo."
+ui_print " "
+ui_print "- Este módulo monitoreará los arranques para detectar"
+ui_print "  y recuperarse de posibles 'bootloops' causados por"
+ui_print "  otros módulos de Magisk."
+ui_print " "
+ui_print "- Si se detecta un bootloop, los módulos se"
+ui_print "  deshabilitarán y el causante (si se identifica)"
+ui_print "  se mostrará en la descripción de este módulo."
+ui_print " "
+ui_print "- Los logs de diagnóstico se guardarán en:"
+ui_print "  $LOG_DIR"
+ui_print " "
+
+# NOTA: La función 'grep_prop' es parte del entorno de instalación de Magisk y está disponible
+# para ser usada en install.sh, por lo que no necesita ser definida.

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -1,23 +1,50 @@
 #!/system/bin/sh
 
-LOG_DIR=/data/adb/modules/Bootloop_Detector_Guardian/logs
+# Obtener el ID de este módulo dinámicamente para evitar errores.
+SELF_MODULE_ID=$(basename "$(dirname "$0")")
+
+# Definir rutas basadas en el ID del módulo.
+LOG_DIR="/data/adb/modules/$SELF_MODULE_ID/logs"
 LAST_MODULE_LOG="$LOG_DIR/last_active_module.log"
 BOOT_PROGRESS_LOG="$LOG_DIR/boot_progress.log"
 
-echo "$(date) - [post-fs-data.sh] Iniciado." >> "$BOOT_PROGRESS_LOG"
+# Es crucial asegurarse de que el directorio de logs exista antes de usarlo.
+mkdir -p "$LOG_DIR"
 
-for MODULE_PATH in /data/adb/modules/*; do
-    MODULE_ID=$(basename "$MODULE_PATH")
+# Función de log para consistencia.
+log_message() {
+    echo "$(date) - [post-fs-data.sh] - $1" >> "$BOOT_PROGRESS_LOG"
+}
 
-    if [ "$MODULE_ID" = "Boot_Loop_Guardian" ]; then
+log_message "Iniciado. Buscando módulos habilitados..."
+
+# Limpiar el log de la sesión anterior para empezar de cero.
+# Si el script se interrumpe, el último valor que quede será el sospechoso.
+>"$LAST_MODULE_LOG"
+
+# Iterar sobre todos los directorios de módulos.
+# Usar comillas en el globbing es más seguro.
+for module_path in "/data/adb/modules"/*; do
+    # Continuar si la entrada no es un directorio.
+    [ ! -d "$module_path" ] && continue
+    
+    local module_id
+    module_id=$(basename "$module_path")
+
+    # Comparar con el ID dinámico para saltarse a sí mismo.
+    if [ "$module_id" = "$SELF_MODULE_ID" ]; then
         continue
     fi
 
-    if [ ! -f "$MODULE_PATH/disable" ]; then
-        echo "$(date) - [post-fs-data.sh] Módulo habilitado detectado: $MODULE_ID" >> "$BOOT_PROGRESS_LOG"
+    # Comprobar si el módulo está habilitado (es decir, no tiene un archivo 'disable').
+    if [ ! -f "$module_path/disable" ]; then
+        log_message "Módulo habilitado detectado: $module_id"
 
-        echo "$MODULE_ID" > "$LAST_MODULE_LOG"
+        # Sobrescribir el archivo de log con el ID del último módulo habilitado encontrado.
+        # Esto es intencional. Al final del bucle, este archivo solo contendrá
+        # el ID del último módulo de la lista que estaba habilitado.
+        echo "$module_id" > "$LAST_MODULE_LOG"
     fi
 done
 
-echo "$(date) - [post-fs-data.sh] Finalizado. El último módulo registrado en $LAST_MODULE_LOG es el último que Magisk intentó cargar." >> "$BOOT_PROGRESS_LOG"
+log_message "Análisis finalizado. El presunto causante de un posible bootloop se ha registrado."

--- a/service.sh
+++ b/service.sh
@@ -1,177 +1,201 @@
 #!/system/bin/sh
+# MOD=true
 
-LOG_DIR=/data/adb/modules/Bootloop_Detector_Guardian/logs
+# --- INICIO DE CONFIGURACIÓN Y CONSTANTES ---
+
+# Obtener el directorio del módulo dinámicamente
+# $0 es la ruta del script, dirname nos da el directorio.
+# Esto hace el script más portable si la estructura de carpetas cambia.
+MODULE_PATH=$(dirname "$0")
+
+# Definir el ID del módulo a partir de la ruta del script
+# basename nos da el último componente de la ruta (el nombre de la carpeta del módulo)
+SELF_MODULE_ID=$(basename "$MODULE_PATH")
+
+LOG_DIR="/data/adb/modules/$SELF_MODULE_ID/logs"
 LAST_MODULE_LOG="$LOG_DIR/last_active_module.log"
 BOOT_PROGRESS_LOG="$LOG_DIR/boot_progress.log"
-CRASH_LOG="$LOG_DIR/crash_events.log" 
-
+CRASH_LOG="$LOG_DIR/crash_events.log"
 BOOTLOOP_COUNTER_FILE="$LOG_DIR/bootloop_counter.txt"
 
-BOOTLOOP_THRESHOLD=2 
+SELF_MODULE_PROP="/data/adb/modules/$SELF_MODULE_ID/module.prop"
 
-SELF_MODULE_PROP="/data/adb/modules/Bootloop_Detector_Guardian/module.prop"
+# Constantes
+BOOTLOOP_THRESHOLD=2
+DEFAULT_DESCRIPTION="description=Detect and solve a bootloop and verify module that caused a bootloop, in case you installed many modules at the same time."
+
+# --- FIN DE CONFIGURACIÓN Y CONSTANTES ---
 
 
-log_crash_event() {
-    EVENT_MESSAGE="$1"
-    echo "$(date) - CRASH_EVENT: $EVENT_MESSAGE" >> "$CRASH_LOG"
+# --- INICIO DE FUNCIONES HELPER ---
+
+# Función de logging centralizada para un formato consistente.
+# Uso: log_message "Este es mi mensaje"
+log_message() {
+    echo "$(date) - [$SELF_MODULE_ID] - $1" >> "$BOOT_PROGRESS_LOG"
 }
 
-get_module_name() {
-    MODULE_ID="$1"
-    MODULE_PROP_PATH="/data/adb/modules/$MODULE_ID/module.prop"
-    if [ -f "$MODULE_PROP_PATH" ]; then
+# Función para registrar eventos de crash específicos.
+# Uso: log_crash_event "Se detectó un bootloop."
+log_crash_event() {
+    echo "$(date) - CRASH_EVENT: $1" >> "$CRASH_LOG"
+}
 
-        grep "^name=" "$MODULE_PROP_PATH" | cut -d'=' -f2- | tr -d '\r' 
+# Función para obtener el nombre de un módulo de su module.prop
+# Más eficiente y segura usando sed.
+get_module_name() {
+    local module_id="$1"
+    local module_prop_path="/data/adb/modules/$module_id/module.prop"
+
+    if [ -f "$module_prop_path" ]; then
+        # Usamos sed para buscar la línea que empieza por "name=" y eliminar esa parte.
+        # Es más eficiente que cat|grep|cut.
+        # 's/^name=//; s/\r$//' -> s/original/reemplazo/; s/\r$// elimina el retorno de carro (CR)
+        sed -n 's/^name=//p' "$module_prop_path" | tr -d '\r'
     else
         echo "[Nombre no encontrado]"
     fi
 }
 
-
-disable_all_magisk_modules() {
-    echo "$(date) - [service.sh] Deshabilitando todos los módulos Magisk..." >> "$BOOT_PROGRESS_LOG"
-
-    CAUSING_MODULE_ID=""
-    if [ -f "$LAST_MODULE_LOG" ]; then
-        CAUSING_MODULE_ID=$(cat "$LAST_MODULE_LOG" | head -n 1 | tr -d '\r')
-    fi
-
-    if [ -n "$CAUSING_MODULE_ID" ] && [ "$CAUSING_MODULE_ID" != "Modulo 'Bootloop Detector Guardian' instalado." ]; then
-        CAUSING_MODULE_NAME=$(get_module_name "$CAUSING_MODULE_ID")
-        NEW_DESCRIPTION_LINE="description=BOOTLOOP DETECTADO! CAUSANTE: ID=$CAUSING_MODULE_ID, Nombre='$CAUSING_MODULE_NAME'."
-        
-        echo "$(date) - [service.sh] Módulo causante identificado: ID=$CAUSING_MODULE_ID, Nombre='$CAUSING_MODULE_NAME'" >> "$BOOT_PROGRESS_LOG"
-              
-        awk -v new_desc="$NEW_DESCRIPTION_LINE" '
-            BEGIN { found_desc = 0 }
-            /^description=/ {
-                print new_desc
-                found_desc = 1
-                next
-            }
-            { print }
-            END {
-                if (!found_desc) {
-                    print new_desc
-                }
-            }
-        ' "$SELF_MODULE_PROP" > "$SELF_MODULE_PROP.tmp" && mv "$SELF_MODULE_PROP.tmp" "$SELF_MODULE_PROP"
-        
-        if [ $? -eq 0 ]; then
-            echo "$(date) - [service.sh] module.prop de nuestro módulo actualizado con el causante." >> "$BOOT_PROGRESS_LOG"
-        else
-            echo "$(date) - [service.sh] ERROR: No se pudo actualizar el module.prop." >> "$BOOT_PROGRESS_LOG"
-        fi
+# Función para actualizar la descripción de nuestro propio módulo.
+# Evita la duplicación de código.
+update_self_description() {
+    local new_description="description=$1"
+    # Usamos sed para reemplazar la línea de descripción. Si no existe, la añade al final.
+    # -i hace la edición "in-place", evitando crear un archivo temporal.
+    # Primero comprobamos si la línea existe.
+    if grep -q "^description=" "$SELF_MODULE_PROP"; then
+        # La línea existe, la reemplazamos
+        sed -i "s|^description=.*|$new_description|" "$SELF_MODULE_PROP"
     else
-        echo "$(date) - [service.sh] No se pudo identificar un módulo causante específico." >> "$BOOT_PROGRESS_LOG"
-               
-        NEW_DESCRIPTION_LINE="description=BOOTLOOP DETECTADO! (Causante no identificado, revisar logs)."
-        awk -v new_desc="$NEW_DESCRIPTION_LINE" '
-            BEGIN { found_desc = 0 }
-            /^description=/ {
-                print new_desc
-                found_desc = 1
-                next
-            }
-            { print }
-            END {
-                if (!found_desc) {
-                    print new_desc
-                }
-            }
-        ' "$SELF_MODULE_PROP" > "$SELF_MODULE_PROP.tmp" && mv "$SELF_MODULE_PROP.tmp" "$SELF_MODULE_PROP"
+        # La línea no existe, la añadimos al final
+        echo "$new_description" >> "$SELF_MODULE_PROP"
     fi
 
-    for MODULE_PATH in /data/adb/modules/*; do
-        MODULE_ID=$(basename "$MODULE_PATH")
-        if [ "$MODULE_ID" = "Boot_Loop_Guardian" ]; then
-            continue 
+    if [ $? -eq 0 ]; then
+        log_message "module.prop actualizado correctamente."
+    else
+        log_message "ERROR: No se pudo actualizar module.prop."
+    fi
+}
+
+# Función principal para deshabilitar módulos en caso de bootloop.
+disable_all_magisk_modules() {
+    log_message "Deshabilitando todos los módulos Magisk excepto $SELF_MODULE_ID..."
+
+    local causing_module_id=""
+    if [ -f "$LAST_MODULE_LOG" ]; then
+        # Leemos la primera línea del log del último módulo
+        causing_module_id=$(head -n 1 "$LAST_MODULE_LOG" | tr -d '\r')
+    fi
+
+    if [ -n "$causing_module_id" ] && [ "$causing_module_id" != "Modulo '$SELF_MODULE_ID' instalado." ]; then
+        local causing_module_name
+        causing_module_name=$(get_module_name "$causing_module_id")
+        log_message "Módulo causante identificado: ID=$causing_module_id, Nombre='$causing_module_name'"
+        update_self_description "BOOTLOOP! Causa probable: '$causing_module_name' (ID: $causing_module_id)"
+    else
+        log_message "No se pudo identificar un módulo causante específico."
+        update_self_description "BOOTLOOP DETECTADO! (Causa no identificada, revisar logs)."
+    fi
+
+    # Bucle para deshabilitar todos los módulos excepto el nuestro
+    for module_path in /data/adb/modules/*; do
+        local module_id
+        module_id=$(basename "$module_path")
+        
+        # Comparamos con el ID obtenido dinámicamente
+        if [ "$module_id" = "$SELF_MODULE_ID" ]; then
+            log_message "Saltando deshabilitación de $SELF_MODULE_ID (este módulo)."
+            continue
         fi
-        if [ ! -f "$MODULE_PATH/disable" ]; then
-            touch "$MODULE_PATH/disable"
-            echo "$(date) - [service.sh] Módulo deshabilitado: $MODULE_ID" >> "$BOOT_PROGRESS_LOG"
+
+        # Si el archivo 'disable' no existe, lo creamos.
+        if [ ! -f "$module_path/disable" ]; then
+            touch "$module_path/disable"
+            log_message "Módulo deshabilitado: $module_id"
         fi
     done
 
-    echo "0" > "$BOOTLOOP_COUNTER_FILE" 
-    echo "$(date) - [service.sh] Todos los módulos deshabilitados. Reiniciando ahora..." >> "$BOOT_PROGRESS_LOG"
+    # Reseteamos el contador y reiniciamos
+    echo "0" > "$BOOTLOOP_COUNTER_FILE"
+    log_message "Todos los módulos deshabilitados. Reiniciando ahora..."
     /system/bin/reboot
     exit 0
 }
 
+
+# --- INICIO DE LA LÓGICA PRINCIPAL DEL SCRIPT ---
+
+# Asegurar que el directorio de logs exista
+mkdir -p "$LOG_DIR"
+
+# Incrementar y registrar el contador de arranque
 if [ -f "$BOOTLOOP_COUNTER_FILE" ]; then
-    BOOT_COUNT=$(cat "$BOOTLOOP_COUNTER_FILE")
+    boot_count=$(cat "$BOOTLOOP_COUNTER_FILE")
 else
-    BOOT_COUNT=0
+    boot_count=0
 fi
-BOOT_COUNT=$((BOOT_COUNT + 1))
-echo "$BOOT_COUNT" > "$BOOTLOOP_COUNTER_FILE"
+boot_count=$((boot_count + 1))
+echo "$boot_count" > "$BOOTLOOP_COUNTER_FILE"
 
-echo "$(date) - [service.sh] Iniciado. Intento de arranque #: $BOOT_COUNT" >> "$BOOT_PROGRESS_LOG"
+log_message "Iniciado. Intento de arranque #: $boot_count"
 
-if [ "$BOOT_COUNT" -gt "$BOOTLOOP_THRESHOLD" ]; then
-    echo "$(date) - [service.sh] Umbral de bootloop ($BOOTLOOP_THRESHOLD) superado. Actuando..." >> "$BOOT_PROGRESS_LOG"
+# Comprobar si hemos superado el umbral de bootloop
+if [ "$boot_count" -gt "$BOOTLOOP_THRESHOLD" ]; then
+    log_message "Umbral de bootloop ($BOOTLOOP_THRESHOLD) superado. Tomando acción..."
     log_crash_event "Bootloop detectado: Superado el umbral de arranques fallidos."
     disable_all_magisk_modules
 fi
 
+# Esperar a que el sistema intente arrancar
+# 90 segundos es un tiempo razonable.
 sleep 90
 
-ZYGOTE_PID=$(pidof zygote64 || pidof zygote)
-SYSTEM_SERVER_PID=$(pidof system_server)
-SYSTEM_UI_PID=$(pidof com.android.systemui)
-
-if [ -n "$ZYGOTE_PID" ] && [ -n "$SYSTEM_SERVER_PID" ] && [ -n "$SYSTEM_UI_PID" ]; then
-
-    echo "$(date) - [service.sh] Arranque exitoso detectado. Procesos clave activos." >> "$BOOT_PROGRESS_LOG"
-    echo "0" > "$BOOTLOOP_COUNTER_FILE" 
+# Verificar si los procesos clave del sistema están en ejecución
+if pgrep -f "zygote" >/dev/null && pgrep -f "system_server" >/dev/null && pgrep -f "com.android.systemui" >/dev/null; then
+    # ARRANQUE EXITOSO
+    log_message "Arranque exitoso detectado. Procesos clave activos."
+    echo "0" > "$BOOTLOOP_COUNTER_FILE"
+    # Limpiamos el log del último módulo, ya que el arranque fue bueno.
     echo "" > "$LAST_MODULE_LOG"
 
-    DEFAULT_DESCRIPTION="description=Detect and solve a bootloop and verify module that caused a bootloop, in case you installed many modules at the same time."
-    awk -v default_desc="$DEFAULT_DESCRIPTION" '
-        BEGIN { found_desc = 0 }
-        /^description=/ {
-            print default_desc
-            found_desc = 1
-            next
-        }
-        { print }
-        END {
-            if (!found_desc) {
-                print default_desc
-            }
-        }
-    ' "$SELF_MODULE_PROP" > "$SELF_MODULE_PROP.tmp" && mv "$SELF_MODULE_PROP.tmp" "$SELF_MODULE_PROP"
-    echo "$(date) - [service.sh] Descripcion del modulo restaurada a la normalidad." >> "$BOOT_PROGRESS_LOG"
+    # Restaurar la descripción por defecto
+    update_self_description "$DEFAULT_DESCRIPTION"
+    log_message "Descripción del módulo restaurada a la normalidad."
 
 else
+    # ARRANQUE FALLIDO
+    log_message "Falla en el arranque: Uno o más procesos clave NO están activos."
+    # Opcional: Loguear qué proceso específico falta
+    if ! pgrep -f "zygote" >/dev/null; then log_message "Proceso Zygote no encontrado."; fi
+    if ! pgrep -f "system_server" >/dev/null; then log_message "Proceso System Server no encontrado."; fi
+    if ! pgrep -f "com.android.systemui" >/dev/null; then log_message "Proceso SystemUI no encontrado."; fi
     
-    echo "$(date) - [service.sh] Falla en el arranque: Procesos clave NO activos." >> "$BOOT_PROGRESS_LOG"
-    if [ -z "$ZYGOTE_PID" ]; then echo "$(date) - [service.sh] Zygote no detectado." >> "$BOOT_PROGRESS_LOG"; fi
-    if [ -z "$SYSTEM_SERVER_PID" ]; then echo "$(date) - [service.sh] System Server no detectado." >> "$BOOT_PROGRESS_LOG"; fi
-    if [ -z "$SYSTEM_UI_PID" ]; then echo "$(date) - [service.sh] SystemUI no detectado." >> "$BOOT_PROGRESS_LOG"; fi
-
-    log_crash_event "Arranque fallido: Procesos clave no detectados."
-    disable_all_magisk_modules 
+    log_crash_event "Arranque fallido: Procesos clave no detectados antes de la acción."
+    disable_all_magisk_modules
 fi
 
+# --- BUCLE DE MONITOREO EN TIEMPO REAL (POST-ARRANQUE) ---
 
+log_message "Iniciando monitoreo de logcat en tiempo real..."
 
-touch "$CRASH_LOG"
-
-while true; do
-    logcat -d -s AndroidRuntime:E | grep "FATAL EXCEPTION" >> /dev/null
-    if [ $? -eq 0 ]; then
-        log_crash_event "FATAL EXCEPTION detectada en AndroidRuntime. Ver logcat completo."
-    fi
-
-    logcat -d -s SystemServer:E | grep "System has crashed" >> /dev/null
-    if [ $? -eq 0 ]; then
-        log_crash_event "SystemServer crash detectado. Ver logcat completo."
-    fi
-
-    sleep 300
+# Monitorear logcat de forma eficiente para eventos de crash del sistema
+# -b events: Buffer de eventos, más ligero.
+# -s AndroidRuntime:E *:S -> Muestra solo logs de AndroidRuntime con prioridad Error o superior.
+logcat -b crash -b main -s AndroidRuntime:E SystemServer:E *:S | while read -r line; do
+    # 'case' es más eficiente que múltiples 'if/grep'
+    case "$line" in
+        *"FATAL EXCEPTION"*)
+            log_crash_event "FATAL EXCEPTION detectada en AndroidRuntime. Forzando recuperación."
+            disable_all_magisk_modules
+            ;;
+        *"System has crashed"*)
+            log_crash_event "SystemServer crash detectado. Forzando recuperación."
+            disable_all_magisk_modules
+            ;;
+    esac
 done
 
-echo "$(date) - [service.sh] El bucle de monitoreo ha terminado (no debería)." >> "$BOOT_PROGRESS_LOG"
+# Esta línea solo se alcanzaría si el comando logcat falla por alguna razón.
+log_message "El bucle de monitoreo ha terminado inesperadamente."


### PR DESCRIPTION
Se asegura el uso correcto de comillas dobles en expansiones de variables.

Se evita posible error por logs no existentes con mkdir -p.

Mensajes de ui_print más claros y profesionales.

Se añade documentación en línea para facilitar el mantenimiento.